### PR TITLE
Fix coverage percentage consistency

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,13 +66,15 @@ jobs:
     
     - name: Run tests with coverage
       run: |
-        go test -tags integration -coverprofile=coverage.out -covermode=atomic ./...
-        go tool cover -func=coverage.out
-        # Сохраняем процент покрытия в переменную
-        echo "COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//g')" >> $GITHUB_ENV
+        # Запускаем тесты и сохраняем вывод с покрытием по пакетам
+        go test -tags integration -coverprofile=coverage.out -covermode=atomic ./... 2>&1 | tee test-output.txt
         
-        # Также сохраняем детальную информацию по пакетам
-        go tool cover -func=coverage.out > coverage-details.txt
+        # Извлекаем информацию о покрытии по пакетам
+        grep -E "(coverage:|no test files)" test-output.txt > coverage-by-package.txt || true
+        
+        # Получаем общий процент покрытия
+        go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//g' > total-coverage.txt
+        echo "COVERAGE=$(cat total-coverage.txt)" >> $GITHUB_ENV
       env:
         DB_HOST: localhost
         DB_PORT: 5432
@@ -177,7 +179,7 @@ jobs:
           echo "MASTER_COVERAGE=N/A" >> $GITHUB_ENV
         fi
     
-    # Создаём собственный отчёт о покрытии вместо использования CodeCoverageSummary
+    # Создаём собственный отчёт о покрытии с информацией по пакетам
     - name: Generate coverage report
       run: |
         # Создаём отчёт о покрытии
@@ -188,7 +190,7 @@ jobs:
         <summary>Coverage by package</summary>
         
         \`\`\`
-        $(cat coverage-details.txt)
+        $(cat coverage-by-package.txt)
         \`\`\`
         
         </details>

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,6 +70,9 @@ jobs:
         go tool cover -func=coverage.out
         # Сохраняем процент покрытия в переменную
         echo "COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//g')" >> $GITHUB_ENV
+        
+        # Также сохраняем детальную информацию по пакетам
+        go tool cover -func=coverage.out > coverage-details.txt
       env:
         DB_HOST: localhost
         DB_PORT: 5432
@@ -174,24 +177,22 @@ jobs:
           echo "MASTER_COVERAGE=N/A" >> $GITHUB_ENV
         fi
     
-    - name: Install gocover-cobertura
-      run: go install github.com/boumenot/gocover-cobertura@latest
-    
-    - name: Convert coverage to Cobertura format
-      run: gocover-cobertura < coverage.out > coverage.cobertura.xml
-    
-    - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: coverage.cobertura.xml
-        badge: true
-        fail_below_min: true
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '10 50'
+    # Создаём собственный отчёт о покрытии вместо использования CodeCoverageSummary
+    - name: Generate coverage report
+      run: |
+        # Создаём отчёт о покрытии
+        cat > code-coverage-results.md <<EOF
+        ## Code Coverage: ${{ env.COVERAGE }}%
+        
+        <details>
+        <summary>Coverage by package</summary>
+        
+        \`\`\`
+        $(cat coverage-details.txt)
+        \`\`\`
+        
+        </details>
+        EOF
     
     # Создаём улучшенный комментарий для PR
     - name: Create coverage comment


### PR DESCRIPTION
## Описание

Исправляет несоответствие процентов покрытия в отчётах и улучшает отображение покрытия по пакетам.

## Проблема

1. В PR #4 было замечено, что отображаются разные проценты покрытия:
   - Current Coverage: 34.1% (из `go tool cover`)
   - Code Coverage: 32% (из `CodeCoverageSummary`)

2. Покрытие отображалось для каждого файла отдельно, что создавало слишком длинный список

## Решение

1. **Унификация процентов**:
   - Убрали использование `CodeCoverageSummary`, который считает покрытие по-другому
   - Теперь везде используется единый источник - `go tool cover`

2. **Покрытие по пакетам**:
   - Вместо показа покрытия для каждого файла, теперь показывается покрытие по пакетам
   - Это даёт более компактный и понятный отчёт

## Изменения

- Удалён шаг с `CodeCoverageSummary`
- Добавлен шаг генерации собственного отчёта о покрытии
- Все проценты теперь берутся из `go tool cover`
- Изменён вывод покрытия - теперь по пакетам, а не по файлам

## Пример нового отчёта

```
github.com/ezhdanovskiy/wallets/cmd                     coverage: 0.0% of statements
github.com/ezhdanovskiy/wallets/internal/application    coverage: 0.0% of statements
github.com/ezhdanovskiy/wallets/internal/config         coverage: 0.0% of statements
github.com/ezhdanovskiy/wallets/internal/csv            coverage: 0.0% of statements
github.com/ezhdanovskiy/wallets/internal/dto            coverage: 100.0% of statements
github.com/ezhdanovskiy/wallets/internal/http           coverage: 92.7% of statements
github.com/ezhdanovskiy/wallets/internal/httperr        coverage: 100.0% of statements
github.com/ezhdanovskiy/wallets/internal/service        coverage: 69.2% of statements
```

Это обеспечит консистентность отображения покрытия и более удобный формат отчёта.